### PR TITLE
Added a header file for including termios

### DIFF
--- a/headers.h
+++ b/headers.h
@@ -1,0 +1,1 @@
+#include <termios.h>

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,4 +1,5 @@
 module CGtk [system] {
+  header "headers.h"
   header "/usr/include/gtk-3.0/gtk/gtk.h"
 
   link "gtk-3"


### PR DESCRIPTION
Fixes #3

I added a header file which includes "termios.h" and then updated the module.modulemap to include the added header file. I tested it using 3.1-dev on Ubuntu 16.04 and it compiled fine. Also, this fixes issue 7 in your SwiftGtk repository. The sample application can now be run without any problems.